### PR TITLE
Align menu on the right

### DIFF
--- a/israel-moh-template/content/assets/css/rtl-fixes.css
+++ b/israel-moh-template/content/assets/css/rtl-fixes.css
@@ -11,3 +11,8 @@ h2#artifacts-summary + div.markdown-toc {
 div.markdown-toc {
   float: left;
 }
+
+.navbar {
+  direction: rtl;
+  display: flex;
+}


### PR DESCRIPTION
Make the menu and the ▼ symbol be more right aligned:

![image](https://github.com/vadi2/MRI-Scheduling/assets/110988/adceb4af-1675-4d33-939b-5ba753a490d2)
